### PR TITLE
mirror dmd pull 420, hide segment related code behind TARGET_SEGMENTED

### DIFF
--- a/dm/src/dmc/cc.h
+++ b/dm/src/dmc/cc.h
@@ -1422,9 +1422,12 @@ enum FL
         FLasm,          // (code) an ASM code
 #if TX86
         FLndp,          // saved 8087 register
+#endif
+#if TARGET_SEGMENTED
         FLfardata,      // ref to far data segment
-        FLlocalsize,    // replaced with # of locals in the stack frame
         FLcsdata,       // ref to code segment variable
+#endif
+        FLlocalsize,    // replaced with # of locals in the stack frame
         FLtlsdata,      // thread local storage
         FLbprel,        // ref to variable at fixed offset from frame pointer
         FLframehandler, // ref to C++ frame handler for NT EH
@@ -1438,7 +1441,6 @@ enum FL
         FLgotoff,       // global offset table entry inside this object file
         //FLoncedata,   // link once data
         //FLoncecode,   // link once code
-#endif
 #endif
         FLMAX
 };

--- a/dm/src/dmc/cdef.h
+++ b/dm/src/dmc/cdef.h
@@ -233,7 +233,7 @@ One and only one of these macros must be set by the makefile:
  * This is not quite the same as !SIXTEENBIT, as one could
  * have near/far with 32 bit code.
  */
-#define TARGET_FLAT     (MARS || !TARGET_WINDOS)
+#define TARGET_SEGMENTED     (!MARS && TARGET_WINDOS)
 
 
 #define STATEMENT_SCOPES CPP

--- a/dm/src/dmc/cgcod.c
+++ b/dm/src/dmc/cgcod.c
@@ -2213,8 +2213,10 @@ code *codelem(elem *e,regm_t *pretregs,bool constflag)
                 case TYjhandle:
 #endif
                 case TYnptr:
+#if TARGET_SEGMENTED
                 case TYsptr:
                 case TYcptr:
+#endif
                     *pretregs |= IDXREGS;
                     break;
                 case TYshort:
@@ -2227,11 +2229,11 @@ code *codelem(elem *e,regm_t *pretregs,bool constflag)
                 case TYullong:
                 case TYcent:
                 case TYucent:
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                 case TYfptr:
                 case TYhptr:
-#endif
                 case TYvptr:
+#endif
                     *pretregs |= ALLREGS;
                     break;
             }

--- a/dm/src/dmc/cgcv.c
+++ b/dm/src/dmc/cgcv.c
@@ -406,9 +406,11 @@ void cv_init()
         dttab4[TYptr]  = 0x400;
         dttab4[TYnptr] = 0x400;
         dttab4[TYjhandle] = 0x400;
+#if TARGET_SEGMENTED
         dttab4[TYsptr] = 0x400;
         dttab4[TYcptr] = 0x400;
         dttab4[TYfptr] = 0x500;
+#endif
 
         if (config.flags & CFGeasyomf)
         {   cgcv.LCFDoffset  = EASY_LCFDoffset;
@@ -1546,15 +1548,17 @@ unsigned char cv4_callconv(type *t)
 
     switch (tybasic(t->Tty))
     {
-        case TYnfunc:   call = 0;       break;
+#if TARGET_SEGMENTED
         case TYffunc:   call = 1;       break;
-        case TYnpfunc:  call = 2;       break;
         case TYfpfunc:  call = 3;       break;
         case TYf16func: call = 3;       break;
-        case TYnsfunc:  call = 7;       break;
         case TYfsfunc:  call = 8;       break;
         case TYnsysfunc: call = 9;      break;
         case TYfsysfunc: call = 10;     break;
+#endif
+        case TYnfunc:   call = 0;       break;
+        case TYnpfunc:  call = 2;       break;
+        case TYnsfunc:  call = 7;       break;
         case TYifunc:   call = 1;       break;
         case TYjfunc:   call = 2;       break;
         case TYmfunc:   call = 11;      break;  // this call
@@ -1738,13 +1742,17 @@ L1:
             if (t->Tkey)
                 goto Laarray;
 #endif
+#if TARGET_SEGMENTED
         case TYsptr:
         case TYcptr:
+#endif
         Lptr:
                         attribute |= I32 ? 10 : 0;      goto L2;
+#if TARGET_SEGMENTED
         case TYfptr:
         case TYvptr:    attribute |= I32 ? 11 : 1;      goto L2;
         case TYhptr:    attribute |= 2; goto L2;
+#endif
 
         L2:
 #if 1
@@ -1877,15 +1885,17 @@ L1:
             typidx = cv_debtyp(d);
             break;
 
-        case TYnfunc:
+#if TARGET_SEGMENTED
         case TYffunc:
-        case TYnpfunc:
         case TYfpfunc:
         case TYf16func:
-        case TYnsfunc:
         case TYfsfunc:
         case TYnsysfunc:
         case TYfsysfunc:
+#endif
+        case TYnfunc:
+        case TYnpfunc:
+        case TYnsfunc:
         case TYmfunc:
         case TYjfunc:
         case TYifunc:
@@ -2406,10 +2416,12 @@ STATIC void cv4_func(Funcsym *s)
 #if JHANDLE
             case TYjhandle:
 #endif
-            case TYnullptr:
-            case TYnptr:
+#if TARGET_SEGMENTED
             case TYsptr:
             case TYcptr:
+#endif
+            case TYnullptr:
+            case TYnptr:
                 if (I32)
                     goto case_eax;
                 else
@@ -2427,6 +2439,7 @@ STATIC void cv4_func(Funcsym *s)
                 else
                     goto case_dxax;
 
+#if TARGET_SEGMENTED
             case TYfptr:
             case TYhptr:
                 if (I32)
@@ -2439,6 +2452,7 @@ STATIC void cv4_func(Funcsym *s)
                     goto case_edxebx;
                 else
                     goto case_dxbx;
+#endif
 
             case TYdouble:
             case TYidouble:

--- a/dm/src/dmc/cgen.c
+++ b/dm/src/dmc/cgen.c
@@ -535,12 +535,7 @@ void addtofixlist(symbol *s,targ_size_t soffset,int seg,targ_size_t val,int flag
         ln->Lnext = *pv;
         *pv = ln;
 
-#if TARGET_FLAT
-        numbytes = tysize[TYnptr];
-        if (I64 && !(flags & CFoffset64))
-            numbytes = 4;
-        assert(!(flags & CFseg));
-#else
+#if TARGET_SEGMENTED
         switch (flags & (CFoff | CFseg))
         {
             case CFoff:         numbytes = tysize[TYnptr];      break;
@@ -548,6 +543,11 @@ void addtofixlist(symbol *s,targ_size_t soffset,int seg,targ_size_t val,int flag
             case CFoff | CFseg: numbytes = tysize[TYfptr];      break;
             default:            assert(0);
         }
+#else
+        numbytes = tysize[TYnptr];
+        if (I64 && !(flags & CFoffset64))
+            numbytes = 4;
+        assert(!(flags & CFseg));
 #endif
 #ifdef DEBUG
         assert(numbytes <= sizeof(zeros));
@@ -629,12 +629,14 @@ STATIC int outfixlist_dg(void *parameter, void *pkey, void *pvalue)
         symbol_debug(s);
         //printf("outfixlist '%s' offset %04x\n",s->Sident,ln->Loffset);
 
+#if TARGET_SEGMENTED
         if (tybasic(s->ty()) == TYf16func)
         {
             obj_far16thunk(s);          /* make it into a thunk         */
             searchfixlist(s);
         }
         else
+#endif
         {
             if (s->Sxtrnnum == 0)
             {   if (s->Sclass == SCstatic)

--- a/dm/src/dmc/cod1.c
+++ b/dm/src/dmc/cod1.c
@@ -932,17 +932,27 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
          */
         f = FLconst;
         if (e1isadd &&
-            ((e12->Eoper == OPrelconst && (f = el_fl(e12)) != FLfardata) ||
+            ((e12->Eoper == OPrelconst
+#if TARGET_SEGMENTED
+              && (f = el_fl(e12)) != FLfardata
+#endif
+             ) ||
              (e12->Eoper == OPconst && !I16 && !e1->Ecount && (!I64 || el_signx32(e12)))) &&
             !(I64 && config.flags3 & CFG3pic) &&
             e1->Ecount == e1->Ecomsub &&
+#if TARGET_SEGMENTED
             (!e1->Ecount || (~keepmsk & ALLREGS & mMSW) || (e1ty != TYfptr && e1ty != TYhptr)) &&
+#endif
             tysize(e11->Ety) == REGSIZE
            )
         {   unsigned char t;            /* component of r/m field */
             int ss;
             int ssi;
 
+#if !TARGET_SEGMENTED
+            if (e12->Eoper == OPrelconst)
+                f = el_fl(e12);
+#endif
             /*assert(datafl[f]);*/              /* what if addr of func? */
             if (!I16)
             {   /* Any register can be an index register        */
@@ -956,15 +966,6 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
                     /* Load index register with result of e11->E1       */
                     c = cdisscaledindex(e11,&idxregs,keepmsk);
                     reg = findreg(idxregs);
-#if 0 && TARGET_LINUX
-                    if (f == FLgot || f == FLgotoff)    // config.flags3 & CFG3pic
-                    {
-                        gotref = 1;
-                        pcs->Irm = modregrm(2,0,4);
-                        pcs->Isib = modregrm(ss,reg,BX);
-                    }
-                    else
-#endif
                     {
                         t = stackfl[f] ? 2 : 0;
                         pcs->Irm = modregrm(t,0,4);
@@ -1107,8 +1108,10 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
                 refparam = TRUE;
             else if (f == FLauto || f == FLtmp || f == FLbprel || f == FLfltreg)
                 reflocal = TRUE;
+#if TARGET_SEGMENTED
             else if (f == FLcsdata || tybasic(e12->Ety) == TYcptr)
                 pcs->Iflags |= CFcs;
+#endif
             else
                 assert(f != FLreg);
             pcs->IFL1 = f;
@@ -1124,6 +1127,7 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
                 idxregs = IDXREGS & ~keepmsk;
                 c = cat(c,allocreg(&idxregs,&reg,TYoffset));
 
+#if TARGET_SEGMENTED
                 /* If desired result is a far pointer, we'll have       */
                 /* to load another register with the segment of v       */
                 if (e1ty == TYfptr)
@@ -1136,6 +1140,7 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
                                                 /* MOV msreg,segreg     */
                     c = genregs(c,0x8C,segfl[f],msreg);
                 }
+#endif
                 opsave = pcs->Iop;
                 flagsave = pcs->Iflags;
                 pcs->Iop = 0x8D;
@@ -1172,7 +1177,7 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
             keepmsk & RMstore)
             idxregs |= regcon.mvar;
 
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         switch (e1ty)
         {   case TYfptr:                        /* if far pointer       */
             case TYhptr:
@@ -1377,12 +1382,16 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
             pcs->Iflags |= CFfs;                // add FS: override
 #endif
         }
+#if TARGET_SEGMENTED
         if (s->ty() & mTYcs && LARGECODE)
             goto Lfardata;
+#endif
         goto L3;
     case FLdata:
     case FLudata:
+#if TARGET_SEGMENTED
     case FLcsdata:
+#endif
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
     case FLgot:
     case FLgotoff:
@@ -1413,10 +1422,12 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
                     pcs->Irex |= REX;
             }
         }
+#if TARGET_SEGMENTED
         else if (s->ty() & mTYcs && !(fl == FLextern && LARGECODE))
         {
             pcs->Iflags |= CFcs | CFoff;
         }
+#endif
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
         if (I64 && config.flags3 & CFG3pic &&
             (fl == FLtlsdata || s->ty() & mTYthread))
@@ -1450,8 +1461,9 @@ code *getlvalue(code *pcs,elem *e,regm_t keepmsk)
         break;
     }
 #endif
+#if TARGET_SEGMENTED
     case FLfardata:
-        assert(!TARGET_FLAT);
+#endif
     case FLfunc:                                /* reading from code seg */
         if (config.exe & EX_flat)
             goto L3;
@@ -1704,14 +1716,17 @@ code *fixresult(elem *e,regm_t retregs,regm_t *pretregs)
   forccs = *pretregs & mPSW;
   forregs = *pretregs & (mST01 | mST0 | mBP | ALLREGS | mES | mSTACK | XMMREGS);
   tym = tybasic(e->Ety);
-#if 0
-  if (tym == TYstruct)
-        // Hack to support cdstreq()
-        tym = TYfptr;
-#else
+#if TARGET_SEGMENTED
   if (tym == TYstruct)
         // Hack to support cdstreq()
         tym = (forregs & mMSW) ? TYfptr : TYnptr;
+#else
+  if (tym == TYstruct)
+  {
+        // Hack to support cdstreq()
+        assert(!(forregs & mMSW));
+        tym = TYnptr;
+  }
 #endif
   c = CNIL;
   sz = tysize[tym];
@@ -2287,9 +2302,12 @@ code *cdfunc(elem *e,regm_t *pretregs)
 
             // First compute numpara, the total bytes pushed on the stack
             switch (tyf)
-            {   case TYf16func:
+            {
+#if TARGET_SEGMENTED
+                case TYf16func:
                     stackalign = 2;
                     goto Ldefault;
+#endif
                 case TYmfunc:
                 case TYjfunc:
                     // last parameter goes into register
@@ -2344,9 +2362,12 @@ code *cdfunc(elem *e,regm_t *pretregs)
             }
 
             switch (tyf)
-            {   case TYf16func:
+            {
+#if TARGET_SEGMENTED
+                case TYf16func:
                     stackalign = 2;
                     goto Ldefault2;
+#endif
                 case TYmfunc:   // last parameter goes into ECX
                     preg = CX;
                     goto L1;
@@ -2695,9 +2716,11 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,regm_t *pretre
             s->Sflags &= ~GTregcand;
             s->Sflags |= SFLread;
             ce = cat(c1,cdrelconst(e1,&retregs));
+#if TARGET_SEGMENTED
             if (farfunc)
                 goto LF1;
             else
+#endif
                 goto LF2;
         }
         else
@@ -2750,7 +2773,11 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,regm_t *pretre
         assert(e1->Eoper == OPind);
         e11 = e1->E1;
         e11ty = tybasic(e11->Ety);
+#if TARGET_SEGMENTED
         assert(!I16 || (e11ty == (farfunc ? TYfptr : TYnptr)));
+#else
+        assert(!I16 || (e11ty == TYnptr));
+#endif
 
         /* if we can't use loadea()     */
         if ((EOP(e11) || e11->Eoper == OPconst) &&
@@ -2764,6 +2791,7 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,regm_t *pretre
             cgstate.stackclean--;
             /* Kill registers destroyed by an arbitrary function call */
             ce = cat(ce,getregs((mBP | ALLREGS | mES | XMMREGS) & ~fregsaved));
+#if TARGET_SEGMENTED
             if (e11ty == TYfptr)
             {   unsigned lsreg;
              LF1:
@@ -2781,6 +2809,7 @@ STATIC code * funccall(elem *e,unsigned numpara,unsigned numalign,regm_t *pretre
                         modregrm(2,3,BPRM),FLfltreg,0);
             }
             else
+#endif
             {
              LF2:
                 reg = findreg(retregs);
@@ -3072,6 +3101,7 @@ code *params(elem *e,unsigned stackalign)
                 npushes = sz / pushsize;
                 switch (e1->Eoper)
                 {   case OPind:
+#if TARGET_SEGMENTED
                         if (sz)
                         {   switch (tybasic(e1->E1->Ety))
                             {
@@ -3089,6 +3119,7 @@ code *params(elem *e,unsigned stackalign)
                                     break;
                             }
                         }
+#endif
                         c1 = codelem(e1->E1,&retregs,FALSE);
                         freenode(e1);
                         break;
@@ -3108,12 +3139,13 @@ code *params(elem *e,unsigned stackalign)
                             int fl;
 
                             fl = el_fl(e1);
+#if TARGET_SEGMENTED
                             if (fl == FLfardata)
                             {   seg = CFes;
-                                assert(!TARGET_FLAT);
                                 retregs |= mES;
                             }
                             else
+#endif
                             {
                                 s = segfl[fl];
                                 assert(s < 4);
@@ -3122,7 +3154,7 @@ code *params(elem *e,unsigned stackalign)
                                     seg = 0;
                             }
                         }
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                         if (e1->Ety & mTYfar)
                         {   seg = CFes;
                             retregs |= mES;
@@ -3251,8 +3283,14 @@ code *params(elem *e,unsigned stackalign)
             e1 = e->E1;
             tym1 = tybasic(e1->Ety);
             /* BUG: what about pointers to functions?   */
-            segreg = (tym1 == TYnptr) ? 3<<3 :
-                     (tym1 == TYcptr) ? 1<<3 : 2<<3;
+            switch (tym1)
+            {
+                case TYnptr: segreg = 3<<3; break;
+#if TARGET_SEGMENTED
+                case TYcptr: segreg = 1<<3; break;
+#endif
+                default:     segreg = 2<<3; break;
+            }
             if (I32 && stackalign == 2)
                 c = gen1(c,0x66);               /* push a word          */
             c = gen1(c,0x06 + segreg);          /* PUSH SEGREG          */
@@ -3265,7 +3303,7 @@ code *params(elem *e,unsigned stackalign)
         }
         break;
     case OPrelconst:
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
         /* Determine if we can just push the segment register           */
         /* Test size of type rather than TYfptr because of (long)(&v)   */
         s = e->EV.sp.Vsym;

--- a/dm/src/dmc/debug.c
+++ b/dm/src/dmc/debug.c
@@ -81,10 +81,12 @@ void WRTYxx(tym_t t)
 #if TX86
     if (t & mTYnear)
         dbg_printf("mTYnear|");
+#if TARGET_SEGMENTED
     if (t & mTYfar)
         dbg_printf("mTYfar|");
     if (t & mTYcs)
         dbg_printf("mTYcs|");
+#endif
 #endif
     if (t & mTYconst)
         dbg_printf("mTYconst|");
@@ -279,12 +281,16 @@ void WRFL(enum FL fl)
          "fltrg ","offst ","datsg ",
          "ctor  ","dtor  ","regsav","asm   ",
 #if TX86
-         "ndp   ","farda ","local ","csdat ","tlsdat",
+         "ndp   ",
+#endif
+#if TARGET_SEGMENTED
+         "farda ","csdat ",
+#endif
+         "local ","tlsdat",
          "bprel ","frameh","blocko","alloca",
          "stack ","dsym  ",
 #if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
          "got   ","gotoff",
-#endif
 #endif
         };
 

--- a/dm/src/dmc/dt.c
+++ b/dm/src/dmc/dt.c
@@ -240,7 +240,11 @@ dt_t ** dtcoff(dt_t **pdtend,targ_size_t offset)
     while (*pdtend)
         pdtend = &((*pdtend)->DTnext);
     dt = dt_calloc(DT_coff);
+#if TARGET_SEGMENTED
     dt->Dty = TYcptr;
+#else
+    dt->Dty = TYnptr;
+#endif
     dt->DToffset = offset;
     *pdtend = dt;
     pdtend = &dt->DTnext;

--- a/dm/src/dmc/el.c
+++ b/dm/src/dmc/el.c
@@ -1879,7 +1879,7 @@ elem *el_convstring(elem *e)
     e->EV.ss.Vstring = NULL;
     len = e->EV.ss.Vstrlen;
 
-#if TX86
+#if TARGET_SEGMENTED
     // Handle strings that go into the code segment
     if (tybasic(e->Ety) == TYcptr ||
         (tyfv(e->Ety) && config.flags3 & CFG3strcod))
@@ -2375,8 +2375,10 @@ L1:
 #endif
                     case TYnullptr:
                     case TYnptr:
+#if TARGET_SEGMENTED
                     case TYsptr:
                     case TYcptr:
+#endif
                         if (NPTRSIZE == SHORTSIZE)
                             goto case_short;
                         else if (NPTRSIZE == LONGSIZE)
@@ -2394,7 +2396,7 @@ L1:
                         if (n1->EV.Vschar != n2->EV.Vschar)
                                 goto nomatch;
                         break;
-#if TX86
+#if TARGET_SEGMENTED
                     case TYfptr:
                     case TYhptr:
                     case TYvptr:
@@ -2650,14 +2652,15 @@ L1:
             goto L1;
 #endif
 
-#if TX86
 #if JHANDLE
         case TYjhandle:
 #endif
-        case TYnullptr:
-        case TYnptr:
+#if TARGET_SEGMENTED
         case TYsptr:
         case TYcptr:
+#endif
+        case TYnptr:
+        case TYnullptr:
             if (NPTRSIZE == SHORTSIZE)
                 goto Ushort;
             if (NPTRSIZE == LONGSIZE)
@@ -2665,7 +2668,6 @@ L1:
             if (NPTRSIZE == LLONGSIZE)
                 goto Ullong;
             assert(0);
-#endif
 
         case TYuint:
             if (intsize == SHORTSIZE)
@@ -2674,17 +2676,16 @@ L1:
 
         case TYulong:
         case TYdchar:
+#if TARGET_SEGMENTED
         case TYfptr:
-#if TX86
         case TYhptr:
-#endif
         case TYvptr:
+#endif
         case TYvoid:                    /* some odd cases               */
         Ulong:
             result = e->EV.Vulong;
             break;
 
-#if TX86
         case TYint:
             if (intsize == SHORTSIZE)
                 goto Ishort;
@@ -2694,7 +2695,7 @@ L1:
         Ilong:
             result = e->EV.Vlong;
             break;
-#endif
+
         case TYllong:
         case TYullong:
         Ullong:
@@ -3002,15 +3003,15 @@ void elem_print(elem *e)
                     case TYuchar:
                         dbg_printf("%d ",e->EV.Vuchar);
                         break;
-#if TX86
-                    case TYsptr:
 #if JHANDLE
                     case TYjhandle:
 #endif
-                    case TYnullptr:
-                    case TYnptr:
+#if TARGET_SEGMENTED
+                    case TYsptr:
                     case TYcptr:
 #endif
+                    case TYnullptr:
+                    case TYnptr:
                         if (NPTRSIZE == LONGSIZE)
                             goto L1;
                         if (NPTRSIZE == SHORTSIZE)
@@ -3036,15 +3037,13 @@ void elem_print(elem *e)
                     case TYushort:
                     case TYchar16:
                     L3:
-#if TX86
                         dbg_printf("%d ",e->EV.Vint);
                         break;
-#endif
                     case TYlong:
                     case TYulong:
                     case TYdchar:
+#if TARGET_SEGMENTED
                     case TYfptr:
-#if TX86
                     case TYvptr:
                     case TYhptr:
 #endif
@@ -3101,9 +3100,11 @@ void elem_print(elem *e)
                         dbg_printf("%gL+%gLi ", (double)e->EV.Vcldouble.re, (double)e->EV.Vcldouble.im);
                         break;
 
+#if !MARS
                     case TYident:
                         dbg_printf("'%s' ", e->ET->Tident);
                         break;
+#endif
 
                     default:
                         dbg_printf("Invalid type ");

--- a/dm/src/dmc/evalu8.c
+++ b/dm/src/dmc/evalu8.c
@@ -134,24 +134,25 @@ HINT boolres(elem *e)
                 case TYbool:
                 case TYwchar_t:
                 case TYenum:
+#if !MARS
                 case TYmemptr:
+#endif
                 case TYlong:
                 case TYulong:
                 case TYdchar:
                 case TYllong:
                 case TYullong:
-#if TX86
 #if JHANDLE
                 case TYjhandle:
 #endif
-                //case TYnullptr:
-                case TYnptr:
+#if TARGET_SEGMENTED
                 case TYsptr:
                 case TYcptr:
                 case TYhptr:
-#endif
                 case TYfptr:
                 case TYvptr:
+#endif
+                case TYnptr:
                     b = el_tolong(e) != 0;
                     break;
                 case TYfloat:

--- a/dm/src/dmc/exp2.c
+++ b/dm/src/dmc/exp2.c
@@ -3211,7 +3211,7 @@ STATIC elem * exp2_paramchk(elem *e,type *t,int param)
                             synerr(EM_noaddress);       // can't take address of register
                             break;
                     }
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                     if (pointertype == TYnptr && s->Stype->Tty & mTYfar)
                         cpperr(EM_near2far,s->Sident);  // s is far
 #endif

--- a/dm/src/dmc/gother.c
+++ b/dm/src/dmc/gother.c
@@ -1205,7 +1205,7 @@ void elimass(elem *n)
             /* Don't screw up assnod[]. */
             n->Eoper = OPcomma;
             n->Ety |= n->E2->Ety & (mTYconst | mTYvolatile | mTYimmutable | mTYshared
-#if !TARGET_FLAT
+#if TARGET_SEGMENTED
                  | mTYfar
 #endif
                 );

--- a/dm/src/dmc/nwc.c
+++ b/dm/src/dmc/nwc.c
@@ -3006,7 +3006,7 @@ type *declar(type *t,char *vident,int flag)
 #if TX86
                 switch (tym)
                 {   case mTYfar:
-                        assert(!TARGET_FLAT);
+                        assert(TARGET_SEGMENTED);
                         if (LARGEDATA)
                             break;
                         t->Tty = TYfref;

--- a/dm/src/dmc/optabgen.c
+++ b/dm/src/dmc/optabgen.c
@@ -645,15 +645,21 @@ void fltables()
 
         static char indatafl[] =        /* is FLxxxx a data type?       */
         { FLdata,FLudata,FLreg,FLpseudo,FLauto,FLpara,FLextern,FLtmp,
-          FLcs,FLfltreg,FLallocatmp,FLdatseg,FLndp,FLfardata,FLtlsdata,FLbprel,
+          FLcs,FLfltreg,FLallocatmp,FLdatseg,FLndp,FLtlsdata,FLbprel,
           FLstack,FLregsave };
+#if TARGET_SEGMENTED
+        static char indatafl_s[] = { FLfardata, };
+#endif
 
         static char instackfl[] =       /* is FLxxxx a stack data type? */
         { FLauto,FLpara,FLtmp,FLcs,FLfltreg,FLallocatmp,FLndp,FLbprel,FLstack,FLregsave };
 
         static char inflinsymtab[] =    /* is FLxxxx in the symbol table? */
         { FLdata,FLudata,FLreg,FLpseudo,FLauto,FLpara,FLextern,FLtmp,FLfunc,
-          FLfardata,FLtlsdata,FLbprel,FLcsdata,FLstack };
+          FLtlsdata,FLbprel,FLstack };
+#if TARGET_SEGMENTED
+        static char inflinsymtab_s[] = { FLfardata,FLcsdata, };
+#endif
 
         for (i = 0; i < FLMAX; i++)
                 datafl[i] = stackfl[i] = flinsymtab[i] = 0;
@@ -666,6 +672,14 @@ void fltables()
 
         for (i = 0; i < sizeof(inflinsymtab); i++)
                 flinsymtab[inflinsymtab[i]] = 1;
+
+#if TARGET_SEGMENTED
+        for (i = 0; i < sizeof(indatafl_s); i++)
+                datafl[indatafl_s[i]] = 1;
+
+        for (i = 0; i < sizeof(inflinsymtab_s); i++)
+                flinsymtab[inflinsymtab_s[i]] = 1;
+#endif
 
 /* Segment registers    */
 #define ES      0
@@ -695,12 +709,14 @@ void fltables()
                 case FLblockoff: segfl[i] = CS; break;
                 case FLcs:      segfl[i] = SS;  break;
                 case FLregsave: segfl[i] = SS;  break;
-                case FLcsdata:  segfl[i] = CS;  break;
                 case FLndp:     segfl[i] = SS;  break;
                 case FLswitch:  segfl[i] = -1;  break;
                 case FLfltreg:  segfl[i] = SS;  break;
                 case FLoffset:  segfl[i] = -1;  break;
+#if TARGET_SEGMENTED
                 case FLfardata: segfl[i] = -1;  break;
+                case FLcsdata:  segfl[i] = CS;  break;
+#endif
                 case FLdatseg:  segfl[i] = DS;  break;
                 case FLctor:    segfl[i] = -1;  break;
                 case FLdtor:    segfl[i] = -1;  break;
@@ -747,8 +763,10 @@ void fltables()
 
 void dotytab()
 {
-    static tym_t _ptr[]      = { TYjhandle,TYnptr,TYsptr,TYcptr,TYf16ptr,TYfptr,TYhptr,
-                                 TYvptr };
+    static tym_t _ptr[]      = { TYjhandle,TYnptr };
+#if TARGET_SEGMENTED
+    static tym_t _ptr_nflat[]= { TYsptr,TYcptr,TYf16ptr,TYfptr,TYhptr,TYvptr };
+#endif
     static tym_t _real[]     = { TYfloat,TYdouble,TYdouble_alias,TYldouble,
                                };
     static tym_t _imaginary[] = {
@@ -761,25 +779,37 @@ void dotytab()
                                  TYwchar_t,TYushort,TYenum,TYint,TYuint,
                                  TYlong,TYulong,TYllong,TYullong,TYdchar,
                                  TYchar16, TYcent, TYucent };
-    static tym_t _ref[]      = { TYnref,TYfref,TYref };
-    static tym_t _func[]     = { TYnfunc,TYffunc,TYnpfunc,TYfpfunc,TYf16func,
-                                 TYnsfunc,TYfsfunc,TYifunc,TYmfunc,TYjfunc,
-                                 TYnsysfunc,TYfsysfunc, TYhfunc };
+    static tym_t _ref[]      = { TYnref,TYref };
+    static tym_t _func[]     = { TYnfunc,TYnpfunc,TYnsfunc,TYifunc,TYmfunc,TYjfunc,TYhfunc };
+#if TARGET_SEGMENTED
+    static tym_t _ref_nflat[] = { TYfref };
+    static tym_t _func_nflat[]= { TYffunc,TYfpfunc,TYf16func,TYfsfunc,TYnsysfunc,TYfsysfunc, };
+#endif
     static tym_t _uns[]     = { TYuchar,TYushort,TYuint,TYulong,
 #if MARS
                                 TYwchar_t,
 #endif
                                 TYdchar,TYullong,TYucent,TYchar16 };
+#if !MARS
     static tym_t _mptr[]    = { TYmemptr };
+#endif
     static tym_t _nullptr[] = { TYnullptr };
+#if TARGET_SEGMENTED
 #if OMFOBJ
     static tym_t _fv[]      = { TYfptr, TYvptr };
 #endif
 #if TARGET_WINDOS
     static tym_t _farfunc[] = { TYffunc,TYfpfunc,TYfsfunc,TYfsysfunc };
 #endif
-    static tym_t _pasfunc[] = { TYnpfunc,TYfpfunc,TYf16func,TYnsfunc,TYfsfunc,TYmfunc,TYjfunc };
-    static tym_t _revfunc[] = { TYnpfunc,TYfpfunc,TYf16func,TYjfunc };
+#endif
+    static tym_t _pasfunc[] = { TYnpfunc,TYnsfunc,TYmfunc,TYjfunc };
+#if TARGET_SEGMENTED
+    static tym_t _pasfunc_nf[] = { TYfpfunc,TYf16func,TYfsfunc, };
+#endif
+    static tym_t _revfunc[] = { TYnpfunc,TYjfunc };
+#if TARGET_SEGMENTED
+    static tym_t _revfunc_nf[] = { TYfpfunc,TYf16func, };
+#endif
     static tym_t _short[]     = { TYbool,TYchar,TYschar,TYuchar,TYshort,
                                   TYwchar_t,TYushort,TYchar16 };
     static tym_t _aggregate[] = { TYstruct,TYarray };
@@ -830,39 +860,44 @@ void dotytab()
 "complex double",       TYcdouble,      TYcdouble,  TYcdouble,  2*DOUBLESIZE,0x89,0x51,
 "complex long double",  TYcldouble,     TYcldouble, TYcldouble, 2*LNGDBLSIZE,0x89,0x52,
 
-"*",            TYptr,          TYptr,     TYptr,       2,  0x20,       0x100,
 "__near *",     TYjhandle,      TYjhandle, TYjhandle,   2,  0x20,       0x100,
 "nullptr_t",    TYnullptr,      TYnullptr, TYptr,       2,  0x20,       0x100,
 "*",            TYnptr,         TYnptr,    TYnptr,      2,  0x20,       0x100,
+"&",            TYref,          TYref,     TYref,       -1,     0,      0,
+"void",         TYvoid,         TYvoid,    TYvoid,      -1,     0x85,   3,
+"struct",       TYstruct,       TYstruct,  TYstruct,    -1,     0,      0,
+"array",        TYarray,        TYarray,   TYarray,     -1,     0x78,   0,
+"C func",       TYnfunc,        TYnfunc,   TYnfunc,     -1,     0x63,   0,
+"Pascal func",  TYnpfunc,       TYnpfunc,  TYnpfunc,    -1,     0x74,   0,
+"std func",     TYnsfunc,       TYnsfunc,  TYnsfunc,    -1,     0x63,   0,
+"*",            TYptr,          TYptr,     TYptr,       2,  0x20,       0x100,
+"member func",  TYmfunc,        TYmfunc,   TYmfunc,     -1,     0x64,   0,
+"D func",       TYjfunc,        TYjfunc,   TYjfunc,     -1,     0x74,   0,
+"C func",       TYhfunc,        TYhfunc,   TYhfunc,     -1,     0,      0,
+"__near &",     TYnref,         TYnref,    TYnref,      2,      0,      0,
+
+#if TARGET_SEGMENTED
 "__ss *",       TYsptr,         TYsptr,    TYsptr,      2,  0x20,       0x100,
 "__cs *",       TYcptr,         TYcptr,    TYcptr,      2,  0x20,       0x100,
 "__far16 *",    TYf16ptr,       TYf16ptr,  TYf16ptr,    4,  0x40,       0x200,
 "__far *",      TYfptr,         TYfptr,    TYfptr,      4,  0x40,       0x200,
 "__huge *",     TYhptr,         TYhptr,    TYhptr,      4,  0x40,       0x300,
 "__handle *",   TYvptr,         TYvptr,    TYvptr,      4,  0x40,       0x200,
-"struct",       TYstruct,       TYstruct,  TYstruct,    -1,     0,      0,
-"array",        TYarray,        TYarray,   TYarray,     -1,     0x78,   0,
-"&",            TYref,          TYref,     TYref,       -1,     0,      0,
-"__near &",     TYnref,         TYnref,    TYnref,      2,      0,      0,
-"__far &",      TYfref,         TYfref,    TYfref,      4,      0,      0,
-"C func",       TYnfunc,        TYnfunc,   TYnfunc,     -1,     0x63,   0,
-"C func",       TYhfunc,        TYhfunc,   TYhfunc,     -1,     0,      0,
 "far C func",   TYffunc,        TYffunc,   TYffunc,     -1,     0x64,   0,
-"std func",     TYnsfunc,       TYnsfunc,  TYnsfunc,    -1,     0x63,   0,
+"far Pascal func", TYfpfunc,    TYfpfunc,  TYfpfunc,    -1,     0x73,   0,
 "far std func", TYfsfunc,       TYfsfunc,  TYfsfunc,    -1,     0x64,   0,
+"_far16 Pascal func", TYf16func, TYf16func, TYf16func,  -1,     0x63,   0,
 "sys func",     TYnsysfunc,     TYnsysfunc,TYnsysfunc,  -1,     0x63,   0,
 "far sys func", TYfsysfunc,     TYfsysfunc,TYfsysfunc,  -1,     0x64,   0,
-"member func",  TYmfunc,        TYmfunc,   TYmfunc,     -1,     0x64,   0,
-"D func",        TYjfunc,       TYjfunc,   TYjfunc,     -1,     0x74,   0,
+"__far &",      TYfref,         TYfref,    TYfref,      4,      0,      0,
+#endif
+#if !MARS
 "interrupt func", TYifunc,      TYifunc,   TYifunc,     -1,     0x64,   0,
-"_far16 Pascal func", TYf16func, TYf16func, TYf16func,  -1,     0x63,   0,
-"Pascal func",  TYnpfunc,       TYnpfunc,  TYnpfunc,    -1,     0x74,   0,
-"far Pascal func",  TYfpfunc,   TYfpfunc,  TYfpfunc,    -1,     0x73,   0,
-"void",         TYvoid,         TYvoid,    TYvoid,      -1,     0x85,   3,
 "memptr",       TYmemptr,       TYmemptr,  TYmemptr,    -1,     0,      0,
 "ident",        TYident,        TYident,   TYident,     -1,     0,      0,
 "template",     TYtemplate,     TYtemplate, TYtemplate, -1,     0,      0,
 "vtshape",      TYvtshape,      TYvtshape,  TYvtshape,  -1,     0,      0,
+#endif
     };
 
     FILE *f;
@@ -891,14 +926,19 @@ void dotytab()
                      };
 
     T1(_ptr,      TYFLptr);
+#if TARGET_SEGMENTED
+    T1(_ptr_nflat,TYFLptr);
+#endif
     T1(_real,     TYFLreal);
     T1(_integral, TYFLintegral);
     T1(_imaginary,TYFLimaginary);
     T1(_complex,  TYFLcomplex);
     T1(_uns,      TYFLuns);
+#if !MARS
     T1(_mptr,     TYFLmptr);
+#endif
 
-#if OMFOBJ
+#if OMFOBJ && TARGET_SEGMENTED
     T1(_fv,       TYFLfv);
     T2(_farfunc,  TYFLfarfunc);
 #endif
@@ -909,7 +949,12 @@ void dotytab()
     T2(_ref,      TYFLref);
     T2(_func,     TYFLfunc);
     T2(_nullptr,  TYFLnullptr);
-
+#if TARGET_SEGMENTED
+    T2(_pasfunc_nf, TYFLpascal);
+    T2(_revfunc_nf, TYFLrevparam);
+    T2(_ref_nflat,  TYFLref);
+    T2(_func_nflat, TYFLfunc);
+#endif
 #undef T1
 #undef T2
 

--- a/dm/src/dmc/out.c
+++ b/dm/src/dmc/out.c
@@ -144,6 +144,7 @@ void outdata(symbol *s)
 #else
                 targ_size_t *poffset;
                 datasize += size(dt->Dty);
+#if TARGET_SEGMENTED
                 if (tybasic(dt->Dty) == TYcptr)
                 {   seg = cseg;
                     poffset = &Coffset;
@@ -157,6 +158,7 @@ void outdata(symbol *s)
                 }
 #endif
                 else
+#endif
                 {   seg = DATA;
                     poffset = &Doffset;
                 }
@@ -192,6 +194,7 @@ void outdata(symbol *s)
                      */
                     switch (ty & mTYLINK)
                     {
+#if TARGET_SEGMENTED
 #if OMFOBJ
                         case mTYfar:                    // if far data
                             seg = obj_fardata(s->Sident,datasize,&s->Soffset);
@@ -207,6 +210,7 @@ void outdata(symbol *s)
                             Coffset += datasize;
                             s->Sfl = FLcsdata;
                             break;
+#endif
                         case mTYthread:
                         {   seg_data *pseg = obj_tlsseg_bss();
 #if ELFOBJ || MACHOBJ
@@ -297,6 +301,7 @@ void outdata(symbol *s)
 #endif
         switch (ty & mTYLINK)
         {
+#if TARGET_SEGMENTED
 #if OMFOBJ
             case mTYfar:                // if far data
                 s->Sfl = FLfardata;
@@ -305,6 +310,7 @@ void outdata(symbol *s)
             case mTYcs:
                 s->Sfl = FLcsdata;
                 break;
+#endif
             case mTYnear:
             case 0:
                 s->Sfl = FLdata;        // initialized data
@@ -324,6 +330,7 @@ void outdata(symbol *s)
     {
       switch (ty & mTYLINK)
       {
+#if TARGET_SEGMENTED
 #if OMFOBJ
         case mTYfar:                    // if far data
             seg = obj_fardata(s->Sident,datasize,&s->Soffset);
@@ -337,6 +344,7 @@ void outdata(symbol *s)
             s->Soffset = Coffset;
             s->Sfl = FLcsdata;
             break;
+#endif
         case mTYthread:
         {   seg_data *pseg = obj_tlsseg();
 #if ELFOBJ || MACHOBJ
@@ -402,13 +410,15 @@ void outdata(symbol *s)
                     flags = CFoff | CFseg;
                 if (I64)
                     flags |= CFoffset64;
+#if TARGET_SEGMENTED
                 if (tybasic(dt->Dty) == TYcptr)
                     reftocodseg(seg,offset,dt->DTabytes);
-#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
                 else
+#endif
+#if TARGET_LINUX || TARGET_OSX || TARGET_FREEBSD || TARGET_OPENBSD || TARGET_SOLARIS
                     reftodatseg(seg,offset,dt->DTabytes,dt->DTseg,flags);
 #else
-                else if (dt->DTseg == DATA)
+                /*else*/ if (dt->DTseg == DATA)
                     reftodatseg(seg,offset,dt->DTabytes,DATA,flags);
                 else
                     reftofarseg(seg,offset,dt->DTabytes,dt->DTseg,flags);
@@ -488,6 +498,7 @@ void outcommon(symbol *s,targ_size_t n)
     if (n != 0)
     {
         assert(s->Sclass == SCglobal);
+#if TARGET_SEGMENTED
         if (s->ty() & mTYcs) // if store in code segment
         {
             /* COMDEFs not supported in code segment
@@ -499,7 +510,9 @@ void outcommon(symbol *s,targ_size_t n)
             out_extdef(s);
 #endif
         }
-        else if (s->ty() & mTYthread) // if store in thread local segment
+        else
+#endif
+        if (s->ty() & mTYthread) // if store in thread local segment
         {
 #if ELFOBJ
             s->Sclass = SCcomdef;

--- a/dm/src/dmc/rtlsym.c
+++ b/dm/src/dmc/rtlsym.c
@@ -66,12 +66,12 @@ void rtlsym_init()
         }
 
 #if MARS
-        type *t = type_fake(LARGECODE ? TYffunc : TYnfunc);
+        type *t = type_fake(TYnfunc);
         t->Tmangle = mTYman_c;
         t->Tcount++;
 
         // Variadic function
-        type *tv = type_fake(LARGECODE ? TYffunc : TYnfunc);
+        type *tv = type_fake(TYnfunc);
         tv->Tmangle = mTYman_c;
         tv->Tcount++;
 #endif

--- a/dm/src/dmc/struct.c
+++ b/dm/src/dmc/struct.c
@@ -39,7 +39,7 @@
 static char __file__[] = __FILE__;      /* for tassert.h                */
 #include        "tassert.h"
 
-#if TARGET_FLAT
+#if !TARGET_SEGMENTED
 #undef mTYfar
 #define mTYfar 0
 #endif

--- a/dm/src/dmc/ty.h
+++ b/dm/src/dmc/ty.h
@@ -63,51 +63,55 @@ enum TYM
     TYcdouble           = 0x19,
     TYcldouble          = 0x1A,
 
-#if TX86
     TYjhandle           = 0x1B, // Jupiter handle type, equals TYnptr except
                                 // that the debug type is different so the
                                 // debugger can distinguish them
     TYnullptr           = 0x1C,
     TYnptr              = 0x1D, // data segment relative pointer
+    TYref               = 0x24, // reference to another type
+    TYvoid              = 0x25,
+    TYstruct            = 0x26, // watch tyaggregate()
+    TYarray             = 0x27, // watch tyaggregate()
+    TYnfunc             = 0x28, // near C func
+    TYnpfunc            = 0x2A, // near Cpp func
+    TYnsfunc            = 0x2C, // near stdcall func
+    TYifunc             = 0x2E, // interrupt func
+    TYptr               = 0x33, // generic pointer type
+    TYmfunc             = 0x37, // NT C++ member func
+    TYjfunc             = 0x38, // LINKd D function
+    TYhfunc             = 0x39, // C function with hidden parameter
+    TYnref              = 0x3A, // near reference
+
+    TYcent              = 0x3C, // 128 bit signed integer
+    TYucent             = 0x3D, // 128 bit unsigned integer
+
+#if TARGET_SEGMENTED
     TYsptr              = 0x1E, // stack segment relative pointer
     TYcptr              = 0x1F, // code segment relative pointer
     TYf16ptr            = 0x20, // special OS/2 far16 pointer
     TYfptr              = 0x21, // far pointer (has segment and offset)
     TYhptr              = 0x22, // huge pointer (has segment and offset)
     TYvptr              = 0x23, // __handle pointer (has segment and offset)
-    TYref               = 0x24, // reference to another type
-    TYvoid              = 0x25,
-    TYstruct            = 0x26, // watch tyaggregate()
-    TYarray             = 0x27, // watch tyaggregate()
-    TYnfunc             = 0x28, // near C func
     TYffunc             = 0x29, // far  C func
-    TYnpfunc            = 0x2A, // near Cpp func
     TYfpfunc            = 0x2B, // far  Cpp func
-    TYnsfunc            = 0x2C, // near stdcall func
     TYfsfunc            = 0x2D, // far stdcall func
-    TYifunc             = 0x2E, // interrupt func
+    TYf16func           = 0x34, // _far16 _pascal function
+    TYnsysfunc          = 0x35, // near __syscall func
+    TYfsysfunc          = 0x36, // far __syscall func
+    TYfref              = 0x3B, // far reference
+#endif
+
+#if !MARS
     TYmemptr            = 0x2F, // pointer to member
     TYident             = 0x30, // type-argument
     TYtemplate          = 0x31, // unexpanded class template
     TYvtshape           = 0x32, // virtual function table
-    TYptr               = 0x33, // generic pointer type
-    TYf16func           = 0x34, // _far16 _pascal function
-    TYnsysfunc          = 0x35, // near __syscall func
-    TYfsysfunc          = 0x36, // far __syscall func
-    TYmfunc             = 0x37, // NT C++ member func
-    TYjfunc             = 0x38, // LINKd D function
-    TYhfunc             = 0x39, // C function with hidden parameter
-    TYnref              = 0x3A, // near reference
-    TYfref              = 0x3B, // far reference
-
-    TYcent              = 0x3C, // 128 bit signed integer
-    TYucent             = 0x3D, // 128 bit unsigned integer
+#endif
 
 #if MARS
 #define TYaarray        TYnptr
 #define TYdelegate      (I64 ? TYcent : TYllong)
 #define TYdarray        (I64 ? TYucent : TYullong)
-#endif
 #endif
 
     TYMAX               = 0x3E,
@@ -119,8 +123,10 @@ extern int TYptrdiff, TYsize, TYsize_t;
 
 /* Linkage type                 */
 #define mTYnear         0x100
+#if TARGET_SEGMENTED
 #define mTYfar          0x200
 #define mTYcs           0x400           // in code segment
+#endif
 #define mTYthread       0x800
 #define mTYLINK         0xF00           // all linkage bits
 

--- a/dm/src/dmc/type.c
+++ b/dm/src/dmc/type.c
@@ -69,18 +69,18 @@ targ_size_t type_size(type *t)
         switch (tyb)
         {
             // in case program plays games with function pointers
+#if TARGET_SEGMENTED
             case TYffunc:
             case TYfpfunc:
-#if TX86
-            case TYnfunc:       /* in case program plays games with function pointers */
-            case TYhfunc:
-            case TYnpfunc:
-            case TYnsfunc:
             case TYfsfunc:
             case TYf16func:
+#endif
+            case TYhfunc:
+            case TYnfunc:       /* in case program plays games with function pointers */
+            case TYnpfunc:
+            case TYnsfunc:
             case TYifunc:
             case TYjfunc:
-#endif
 #if SCPP
                 if (ANSI)
                     synerr(EM_unknown_size,"function"); /* size of function is not known */
@@ -239,7 +239,9 @@ type *type_alloc(tym_t ty)
 {   type *t;
     static type tzero;
 
+#if TARGET_SEGMENTED
     assert(tybasic(ty) != TYtemplate);
+#endif
     if (type_list)
     {   t = type_list;
         type_list = t->Tnext;
@@ -267,6 +269,7 @@ type *type_alloc(tym_t ty)
  * Allocate a TYtemplate.
  */
 
+#if !MARS
 type *type_alloc_template(symbol *s)
 {   type *t;
 
@@ -288,6 +291,7 @@ type *type_alloc_template(symbol *s)
 #endif
     return t;
 }
+#endif
 
 /*****************************
  * Fake a type & initialize it.
@@ -332,6 +336,7 @@ type *type_allocn(tym_t ty,type *tn)
  * Allocate a TYmemptr type.
  */
 
+#if !MARS
 type *type_allocmemptr(Classsym *stag,type *tn)
 {   type *t;
 
@@ -343,6 +348,7 @@ type *type_allocmemptr(Classsym *stag,type *tn)
     //type_print(t);
     return t;
 }
+#endif
 
 /*****************************
  * Free up data type.
@@ -364,10 +370,12 @@ void type_free(type *t)
         {   param_free(&t->Tparamtypes);
             list_free(&t->Texcspec, (list_free_fp)type_free);
         }
+#if !MARS
         else if (ty == TYtemplate)
             param_free(&t->Tparamtypes);
         else if (ty == TYident)
             MEM_PH_FREE(t->Tident);
+#endif
         else if (t->Tflags & TFvla && t->Tel)
             el_free(t->Tel);
 #if SCPP
@@ -462,15 +470,22 @@ void type_init()
     }
 
     // Type of trace function
+#if TARGET_SEGMENTED
     tstrace = type_fake(I16 ? TYffunc : TYnfunc);
+#else
+    tstrace = type_fake(TYnfunc);
+#endif
     tstrace->Tmangle = mTYman_c;
     tstrace->Tcount++;
 
-#if TX86
     chartype = (config.flags3 & CFG3ju) ? tsuchar : tschar;
 
     // Type of far library function
-    tsclib =    type_fake(LARGECODE ? TYfpfunc : TYnpfunc);
+#if TARGET_SEGMENTED
+    tsclib = type_fake(LARGECODE ? TYfpfunc : TYnpfunc);
+#else
+    tsclib = type_fake(TYnpfunc);
+#endif
     tsclib->Tmangle = mTYman_c;
     tsclib->Tcount++;
 
@@ -502,18 +517,6 @@ void type_init()
             tsptr2types[i]->Tcount++;
         }
     }
-#else
-    chartype = tschar;                          /* default is signed chars */
-
-    type_list = NULL;
-    tsclib = type_fake( TYffunc );
-    tsclib->Tmangle = mTYman_c;
-    tsclib->Tcount++;
-#ifdef DEBUG
-    type_num = 0;
-    type_max = 0;
-#endif /* DEBUG */
-#endif /* TX86 */
 }
 
 /**********************************
@@ -578,21 +581,26 @@ type *type_copy(type *t)
     param_t *p;
 
     type_debug(t);
+#if !MARS
     if (tybasic(t->Tty) == TYtemplate)
     {
         tn = type_alloc_template(((typetemp_t *)t)->Tsym);
     }
     else
+#endif
         tn = type_alloc(t->Tty);
     *tn = *t;
     switch (tybasic(tn->Tty))
-    {       case TYtemplate:
+    {
+#if !MARS
+            case TYtemplate:
                 ((typetemp_t *)tn)->Tsym = ((typetemp_t *)t)->Tsym;
                 goto L1;
 
             case TYident:
                 tn->Tident = (char *)MEM_PH_STRDUP(t->Tident);
                 break;
+#endif
 
             case TYarray:
                 if (tn->Tflags & TFvla)
@@ -792,7 +800,11 @@ int type_isdependent(type *t)
         type_debug(t);
         if (t->Tflags & TFdependent)
             goto Lisdependent;
-        if (tyfunc(t->Tty) || tybasic(t->Tty) == TYtemplate)
+        if (tyfunc(t->Tty)
+#if TARGET_SEGMENTED
+                || tybasic(t->Tty) == TYtemplate
+#endif
+                )
         {
             for (param_t *p = t->Tparamtypes; p; p = p->Pnext)
             {
@@ -897,21 +909,26 @@ void type_print(type *t)
   dbg_printf(" Tcount=%d",t->Tcount);
   if (!(t->Tflags & TFsizeunknown) &&
         tybasic(t->Tty) != TYvoid &&
+#if !MARS
         tybasic(t->Tty) != TYident &&
+        tybasic(t->Tty) != TYtemplate &&
+#endif
         tybasic(t->Tty) != TYmfunc &&
-        tybasic(t->Tty) != TYarray &&
-        tybasic(t->Tty) != TYtemplate)
+        tybasic(t->Tty) != TYarray)
       dbg_printf(" Tsize=%ld",type_size(t));
   dbg_printf(" Tnext=%p",t->Tnext);
   switch (tybasic(t->Tty))
   {     case TYstruct:
+#if !MARS
         case TYmemptr:
+#endif
             dbg_printf(" Ttag=%p,'%s'",t->Ttag,t->Ttag->Sident);
             //dbg_printf(" Sfldlst=%p",t->Ttag->Sstruct->Sfldlst);
             break;
         case TYarray:
             dbg_printf(" Tdim=%ld",t->Tdim);
             break;
+#if !MARS
         case TYident:
             dbg_printf(" Tident='%s'",t->Tident);
             break;
@@ -936,6 +953,7 @@ dbg_printf("Pident=%p,Ptype=%p,Pelem=%p,Pnext=%p ",p->Pident,p->Ptype,p->Pelem,p
                 }
             }
             break;
+#endif
         default:
             if (tyfunc(t->Tty))
             {   param_t *p;
@@ -1439,7 +1457,9 @@ int typematch(type *t1,type *t2,int relax)
 
             (tybasic(t1ty) != TYstruct
                 && tybasic(t1ty) != TYenum
+#if !MARS
                 && tybasic(t1ty) != TYmemptr
+#endif
              || t1->Ttag == t2->Ttag)
                  &&
 


### PR DESCRIPTION
mirror dmd pull 420, hide segment related code behind TARGET_SEGMENTED (was TARGET_FLAT).

Only changes from the dmd pull is the addition of three files: exp2.c nwc.c struct.c
Each has trivial changes.
