### PR TITLE
Makefile: Use a single version of dmd, from path

### DIFF
--- a/dm/src/dmc/makefile
+++ b/dm/src/dmc/makefile
@@ -12,8 +12,6 @@
 # Paths:
 
 DMCDIR=\dm
-DMDDIR=e:\dmd2.074
-DMDDIR79=e:\dmd2.079
 
 CBX=.
 NTDLLSHELL=ntdllshell
@@ -65,8 +63,7 @@ LFLAGS=/map/e/f/packcode/noe;
 ##### Tools
 
 # D compiler
-DMD=$(DMDDIR)\windows\bin\dmd
-DMD79=$(DMDDIR79)\windows\bin\dmd
+DMD=dmd
 # C++ compiler
 CC=dmc
 # Make program
@@ -418,7 +415,7 @@ barray.obj : barray.d
         $(DMD) -c $(DFLAGS) barray.d
 
 bcomplex.obj : bcomplex.d
-        $(DMD79) -c $(DFLAGS) bcomplex.d
+        $(DMD) -c $(DFLAGS) bcomplex.d
 
 blockopt.obj : blockopt.d
         $(DMD) -c $(DFLAGS) blockopt.d
@@ -535,7 +532,7 @@ dnwc.obj : dnwc.d
         $(DMD) -c $(DFLAGS) dnwc.d
 
 dph.obj : dph.d page.di
-        $(DMD79) -c $(DFLAGS) dph.d
+        $(DMD) -c $(DFLAGS) dph.d
 
 dpragma.obj : dpragma.d
         $(DMD) -c $(DFLAGS) dpragma.d
@@ -547,10 +544,10 @@ dspeller.obj : dspeller.d
         $(DMD) -c $(DFLAGS) dspeller.d
 
 dtemplate.obj : dtemplate.d
-        $(DMD79) -c $(DFLAGS) dtemplate.d
+        $(DMD) -c $(DFLAGS) dtemplate.d
 
 dtype.obj : dtype.d
-        $(DMD79) -c $(DFLAGS) dtype.d
+        $(DMD) -c $(DFLAGS) dtype.d
 
 dwarfeh.obj : dwarfeh.d
         $(DMD) -c $(DFLAGS) dwarfeh.d


### PR DESCRIPTION
The usage of two versions of DMD seems to be to work around old compiler issues.
Nowadays, DMD 2.079.0 is old enough (released 2018-03-01)
that it can be set as the mainline.
Finally, instead of used fixed locations that are dependent on the developer's setup,
simply use the DMD that should be in the PATH.